### PR TITLE
Add crud e2e

### DIFF
--- a/test/common/util.go
+++ b/test/common/util.go
@@ -18,7 +18,9 @@ package common
 
 // TestLogger defines operations common across different types of testing
 type TestLogger interface {
+	Errorf(format string, args ...interface{})
+	Fatal(args ...interface{})
 	Fatalf(format string, args ...interface{})
-	Fatal(msg string)
+	Log(args ...interface{})
 	Logf(format string, args ...interface{})
 }

--- a/test/e2e/crud.go
+++ b/test/e2e/crud.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+
+	"github.com/marun/fnord/pkg/federatedtypes"
+	"github.com/marun/fnord/test/common"
+	"github.com/marun/fnord/test/e2e/framework"
+
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("Federated types", func() {
+	f := framework.NewFederationFramework("federated-types")
+
+	typeConfigs := federatedtypes.FederatedTypeConfigs()
+	for kind, _ := range typeConfigs {
+		// Bind the type config inside the loop to ensure the ginkgo
+		// closure gets a different value for every loop iteration.
+		//
+		// Reference: https://github.com/golang/go/wiki/CommonMistakes#using-goroutines-on-loop-iterator-variables
+		typeConfig := typeConfigs[kind]
+
+		Describe(fmt.Sprintf("%q resources", kind), func() {
+			It("should be created, read, updated and deleted successfully", func() {
+				// Initialize an in-memory controller if configuration requires
+				f.SetUpControllerFixture(kind, typeConfig.AdapterFactory)
+
+				userAgent := fmt.Sprintf("crud-test-%s", kind)
+				adapter := typeConfig.AdapterFactory(f.FedClient(userAgent))
+				clusterClients := f.ClusterClients(userAgent)
+				crudTester := common.NewFederatedTypeCrudTester(framework.NewE2ELogger(), adapter, clusterClients, framework.PollInterval, framework.SingleCallTimeout)
+				obj := federatedtypes.NewTestObject(typeConfig.Kind, f.TestNamespaceName())
+
+				crudTester.CheckLifecycle(obj)
+			})
+		})
+	}
+})

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/marun/fnord/test/e2e/framework"
+	"github.com/marun/fnord/test/e2e/framework/ginkgowrapper"
+
+	"github.com/golang/glog"
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/gomega"
+)
+
+// RunE2ETests checks configuration parameters (specified through flags) and then runs
+// E2E tests using the Ginkgo runner.
+// This function is called on each Ginkgo node in parallel mode.
+func RunE2ETests(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgowrapper.Fail)
+	glog.Infof("Starting e2e run %q on Ginkgo node %d", framework.RunId, config.GinkgoConfig.ParallelNode)
+	ginkgo.RunSpecs(t, "Federation e2e suite")
+}
+
+// There are certain operations we only want to run once per overall test invocation
+// (such as deleting old namespaces, or verifying that all system pods are running.
+// Because of the way Ginkgo runs tests in parallel, we must use SynchronizedBeforeSuite
+// to ensure that these operations only run on the first parallel Ginkgo node.
+//
+// This function takes two parameters: one function which runs on only the first Ginkgo node,
+// returning an opaque byte array, and then a second function which runs on all Ginkgo nodes,
+// accepting the byte array.
+var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
+	// Run only on Ginkgo node 1
+
+	if framework.TestContext.TestManagedFederation {
+		framework.SetUpManagedFederation()
+		// TODO(marun) support parallel execution by sending
+		// configuration for test-managed federation to other nodes
+	}
+	// TODO(marun) support deployed federation
+
+	return nil
+
+}, func(data []byte) {
+	// Run on all Ginkgo nodes
+})
+
+// Similar to SynchornizedBeforeSuite, we want to run some operations only once (such as collecting cluster logs).
+// Here, the order of functions is reversed; first, the function which runs everywhere,
+// and then the function that only runs on the first Ginkgo node.
+var _ = ginkgo.SynchronizedAfterSuite(func() {
+	// Run on all Ginkgo nodes
+	framework.Logf("Running AfterSuite actions on all node")
+	framework.RunCleanupActions()
+}, func() {
+	// Run only Ginkgo on node 1
+	framework.Logf("Running AfterSuite actions on node 1")
+	if framework.TestContext.TestManagedFederation {
+		framework.TearDownManagedFederation()
+	}
+})

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/marun/fnord/test/e2e/framework"
+)
+
+func init() {
+	framework.ParseFlags()
+}
+
+func TestE2E(t *testing.T) {
+	RunE2ETests(t)
+}

--- a/test/e2e/framework/cleanup.go
+++ b/test/e2e/framework/cleanup.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import "sync"
+
+type CleanupActionHandle *int
+
+var cleanupActionsLock sync.Mutex
+var cleanupActions = map[CleanupActionHandle]func(){}
+
+// AddCleanupAction installs a function that will be called in the event of the
+// whole test being terminated.  This allows arbitrary pieces of the overall
+// test to hook into SynchronizedAfterSuite().
+func AddCleanupAction(fn func()) CleanupActionHandle {
+	p := CleanupActionHandle(new(int))
+	cleanupActionsLock.Lock()
+	defer cleanupActionsLock.Unlock()
+	cleanupActions[p] = fn
+	return p
+}
+
+// RemoveCleanupAction removes a function that was installed by
+// AddCleanupAction.
+func RemoveCleanupAction(p CleanupActionHandle) {
+	cleanupActionsLock.Lock()
+	defer cleanupActionsLock.Unlock()
+	delete(cleanupActions, p)
+}
+
+// RunCleanupActions runs all functions installed by AddCleanupAction.  It does
+// not remove them (see RemoveCleanupAction) but it does run unlocked, so they
+// may remove themselves.
+func RunCleanupActions() {
+	list := []func(){}
+	func() {
+		cleanupActionsLock.Lock()
+		defer cleanupActionsLock.Unlock()
+		for _, fn := range cleanupActions {
+			list = append(list, fn)
+		}
+	}()
+	// Run unlocked.
+	for _, fn := range list {
+		fn()
+	}
+}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	fedclientset "github.com/marun/fnord/pkg/client/clientset_generated/clientset"
+	"github.com/marun/fnord/pkg/federatedtypes"
+	kubeclientset "k8s.io/client-go/kubernetes"
+	crclientset "k8s.io/cluster-registry/pkg/client/clientset_generated/clientset"
+
+	"github.com/onsi/ginkgo"
+)
+
+// FederationFramework provides an interface to a test federation so
+// that the implementation can vary without affecting tests.
+type FederationFramework interface {
+	BeforeEach()
+	AfterEach()
+
+	FedClient(userAgent string) fedclientset.Interface
+	KubeClient(userAgent string) kubeclientset.Interface
+	CrClient(userAgent string) crclientset.Interface
+
+	ClusterClients(userAgent string) []kubeclientset.Interface
+
+	// Name of the namespace for the current test to target
+	TestNamespaceName() string
+
+	// Initialize and cleanup in-memory controller (useful for debugging)
+	SetUpControllerFixture(kind string, adapterFactory federatedtypes.AdapterFactory)
+}
+
+// A framework needs to be instantiated before tests are executed to
+// ensure registration of BeforeEach/AfterEach.  However, flags that
+// dictate which framework should be used won't have been parsed yet.
+// The workaround is using a wrapper that performs late-binding on the
+// framework flavor.
+type frameworkWrapper struct {
+	impl     FederationFramework
+	baseName string
+}
+
+func NewFederationFramework(baseName string) FederationFramework {
+	f := &frameworkWrapper{
+		baseName: baseName,
+	}
+	ginkgo.AfterEach(f.AfterEach)
+	ginkgo.BeforeEach(f.BeforeEach)
+	return f
+}
+
+func (f *frameworkWrapper) framework() FederationFramework {
+	if f.impl == nil {
+		if TestContext.TestManagedFederation {
+			f.impl = NewManagedFramework(f.baseName)
+		} else {
+			f.impl = NewUnmanagedFramework(f.baseName)
+		}
+	}
+	return f.impl
+}
+
+func (f *frameworkWrapper) BeforeEach() {
+	f.framework().BeforeEach()
+}
+
+func (f *frameworkWrapper) AfterEach() {
+	f.framework().AfterEach()
+}
+
+func (f *frameworkWrapper) FedClient(userAgent string) fedclientset.Interface {
+	return f.framework().FedClient(userAgent)
+}
+
+func (f *frameworkWrapper) KubeClient(userAgent string) kubeclientset.Interface {
+	return f.framework().KubeClient(userAgent)
+}
+
+func (f *frameworkWrapper) CrClient(userAgent string) crclientset.Interface {
+	return f.framework().CrClient(userAgent)
+}
+
+func (f *frameworkWrapper) ClusterClients(userAgent string) []kubeclientset.Interface {
+	return f.framework().ClusterClients(userAgent)
+}
+
+func (f *frameworkWrapper) TestNamespaceName() string {
+	return f.framework().TestNamespaceName()
+}
+
+func (f *frameworkWrapper) SetUpControllerFixture(kind string, adapterFactory federatedtypes.AdapterFactory) {
+	f.framework().SetUpControllerFixture(kind, adapterFactory)
+}

--- a/test/e2e/framework/ginkgowrapper/wrapper.go
+++ b/test/e2e/framework/ginkgowrapper/wrapper.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package ginkgowrapper wraps Ginkgo Fail and Skip functions to panic
+// with structured data instead of a constant string.
+package ginkgowrapper
+
+import (
+	"bufio"
+	"bytes"
+	"regexp"
+	"runtime"
+	"runtime/debug"
+	"strings"
+
+	"github.com/onsi/ginkgo"
+)
+
+// FailurePanic is the value that will be panicked from Fail.
+type FailurePanic struct {
+	Message        string // The failure message passed to Fail
+	Filename       string // The filename that is the source of the failure
+	Line           int    // The line number of the filename that is the source of the failure
+	FullStackTrace string // A full stack trace starting at the source of the failure
+}
+
+// String makes FailurePanic look like the old Ginkgo panic when printed.
+func (FailurePanic) String() string { return ginkgo.GINKGO_PANIC }
+
+// Fail wraps ginkgo.Fail so that it panics with more useful
+// information about the failure. This function will panic with a
+// FailurePanic.
+func Fail(message string, callerSkip ...int) {
+	skip := 1
+	if len(callerSkip) > 0 {
+		skip += callerSkip[0]
+	}
+
+	_, file, line, _ := runtime.Caller(skip)
+	fp := FailurePanic{
+		Message:        message,
+		Filename:       file,
+		Line:           line,
+		FullStackTrace: pruneStack(skip),
+	}
+
+	defer func() {
+		e := recover()
+		if e != nil {
+			panic(fp)
+		}
+	}()
+
+	ginkgo.Fail(message, skip)
+}
+
+// SkipPanic is the value that will be panicked from Skip.
+type SkipPanic struct {
+	Message        string // The failure message passed to Fail
+	Filename       string // The filename that is the source of the failure
+	Line           int    // The line number of the filename that is the source of the failure
+	FullStackTrace string // A full stack trace starting at the source of the failure
+}
+
+// String makes SkipPanic look like the old Ginkgo panic when printed.
+func (SkipPanic) String() string { return ginkgo.GINKGO_PANIC }
+
+// Skip wraps ginkgo.Skip so that it panics with more useful
+// information about why the test is being skipped. This function will
+// panic with a SkipPanic.
+func Skip(message string, callerSkip ...int) {
+	skip := 1
+	if len(callerSkip) > 0 {
+		skip += callerSkip[0]
+	}
+
+	_, file, line, _ := runtime.Caller(skip)
+	sp := SkipPanic{
+		Message:        message,
+		Filename:       file,
+		Line:           line,
+		FullStackTrace: pruneStack(skip),
+	}
+
+	defer func() {
+		e := recover()
+		if e != nil {
+			panic(sp)
+		}
+	}()
+
+	ginkgo.Skip(message, skip)
+}
+
+// ginkgo adds a lot of test running infrastructure to the stack, so
+// we filter those out
+var stackSkipPattern = regexp.MustCompile(`onsi/ginkgo`)
+
+func pruneStack(skip int) string {
+	skip += 2 // one for pruneStack and one for debug.Stack
+	stack := debug.Stack()
+	scanner := bufio.NewScanner(bytes.NewBuffer(stack))
+	var prunedStack []string
+
+	// skip the top of the stack
+	for i := 0; i < 2*skip+1; i++ {
+		scanner.Scan()
+	}
+
+	for scanner.Scan() {
+		if stackSkipPattern.Match(scanner.Bytes()) {
+			scanner.Scan() // these come in pairs
+		} else {
+			prunedStack = append(prunedStack, scanner.Text())
+			scanner.Scan() // these come in pairs
+			prunedStack = append(prunedStack, scanner.Text())
+		}
+	}
+
+	return strings.Join(prunedStack, "\n")
+}

--- a/test/e2e/framework/logger.go
+++ b/test/e2e/framework/logger.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"github.com/marun/fnord/test/common"
+)
+
+type e2eLogger struct{}
+
+func NewE2ELogger() common.TestLogger {
+	return e2eLogger{}
+}
+
+func (e2eLogger) Errorf(format string, args ...interface{}) {
+	Errorf(format, args...)
+}
+
+func (e2eLogger) Fatal(args ...interface{}) {
+	// TODO(marun) Is there a nicer way to do this?
+	Failf("%v", args)
+}
+
+func (e2eLogger) Fatalf(format string, args ...interface{}) {
+	Failf(format, args...)
+}
+
+func (e2eLogger) Log(args ...interface{}) {
+	// TODO(marun) Is there a nicer way to do this?
+	Logf("%v", args)
+}
+
+func (e2eLogger) Logf(format string, args ...interface{}) {
+	Logf(format, args...)
+}

--- a/test/e2e/framework/managed.go
+++ b/test/e2e/framework/managed.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"github.com/pborman/uuid"
+
+	fedclientset "github.com/marun/fnord/pkg/client/clientset_generated/clientset"
+	"github.com/marun/fnord/pkg/federatedtypes"
+	"github.com/marun/fnord/test/common"
+	"github.com/marun/fnord/test/integration/framework"
+	kubeclientset "k8s.io/client-go/kubernetes"
+	crclientset "k8s.io/cluster-registry/pkg/client/clientset_generated/clientset"
+)
+
+var (
+	fedFixture *framework.FederationFixture
+	logger     common.TestLogger
+)
+
+func SetUpManagedFederation() {
+	if fedFixture != nil {
+		return
+	}
+	fedFixture = framework.SetUpFederationFixture(NewE2ELogger(), 2)
+}
+
+func TearDownManagedFederation() {
+	if fedFixture != nil {
+		fedFixture.TearDown(NewE2ELogger())
+		fedFixture = nil
+	}
+}
+
+type ManagedFramework struct {
+	// To make sure that this framework cleans up after itself, no matter what,
+	// we install a Cleanup action before each test and clear it after.  If we
+	// should abort, the AfterSuite hook should run all Cleanup actions.
+	cleanupHandle CleanupActionHandle
+
+	logger common.TestLogger
+
+	// Fixtures to cleanup after each test
+	fixtures []framework.TestFixture
+}
+
+func NewManagedFramework(baseName string) FederationFramework {
+	f := &ManagedFramework{
+		logger:   NewE2ELogger(),
+		fixtures: []framework.TestFixture{},
+	}
+	return f
+}
+
+func (f *ManagedFramework) BeforeEach() {
+	// The fact that we need this feels like a bug in ginkgo.
+	// https://github.com/onsi/ginkgo/issues/222
+	f.cleanupHandle = AddCleanupAction(f.AfterEach)
+}
+
+func (f *ManagedFramework) AfterEach() {
+	RemoveCleanupAction(f.cleanupHandle)
+	for _, fixture := range f.fixtures {
+		fixture.TearDown(f.logger)
+	}
+}
+
+func (f *ManagedFramework) FedClient(userAgent string) fedclientset.Interface {
+	return fedFixture.FedApi.NewClient(f.logger, userAgent)
+}
+
+func (f *ManagedFramework) KubeClient(userAgent string) kubeclientset.Interface {
+	return fedFixture.KubeApi.NewClient(f.logger, userAgent)
+}
+
+func (f *ManagedFramework) CrClient(userAgent string) crclientset.Interface {
+	return fedFixture.CrApi.NewClient(f.logger, userAgent)
+}
+
+func (f *ManagedFramework) ClusterClients(userAgent string) []kubeclientset.Interface {
+	return fedFixture.ClusterClients(f.logger, userAgent)
+}
+
+func (f *ManagedFramework) TestNamespaceName() string {
+	return uuid.New()
+}
+
+func (f *ManagedFramework) SetUpControllerFixture(kind string, adapterFactory federatedtypes.AdapterFactory) {
+	// TODO(marun) check TestContext.InMemoryControllers before setting up controller fixture
+	fedConfig := fedFixture.FedApi.NewConfig(f.logger)
+	kubeConfig := fedFixture.KubeApi.NewConfig(f.logger)
+	crConfig := fedFixture.CrApi.NewConfig(f.logger)
+	fixture := framework.NewControllerFixture(f.logger, kind, adapterFactory, fedConfig, kubeConfig, crConfig)
+	f.fixtures = append(f.fixtures, fixture)
+}

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"flag"
+	"os"
+
+	"github.com/golang/glog"
+)
+
+type TestContextType struct {
+	TestManagedFederation bool
+	InMemoryControllers   bool
+	KubeConfig            string
+	KubeContext           string
+}
+
+var TestContext TestContextType
+
+func registerFlags(t *TestContextType) {
+	flag.BoolVar(&t.TestManagedFederation, "test-managed-federation", false, "Whether the test run should rely on a test-managed federation.")
+	flag.BoolVar(&t.InMemoryControllers, "in-memory-controllers", true, "Whether federation controllers should be started in memory.  Ignored if test-managed-cluster is false")
+	flag.StringVar(&t.KubeConfig, "kubeconfig", os.Getenv("KUBECONFIG"), "Path to kubeconfig containing embedded authinfo.  Ignored if test-managed-cluster is true")
+	flag.StringVar(&t.KubeContext, "context", "", "kubeconfig context to use/override. If unset, will use value from 'current-context'")
+}
+
+func validateFlags(t *TestContextType) {
+	if len(t.KubeConfig) == 0 {
+		glog.Warning("kubeconfig not provided - enabling test-managed federation.")
+		t.TestManagedFederation = true
+	} else if t.TestManagedFederation {
+		glog.Warningf("kubeconfig %q will be ignored due to test-managed-federation being true.", t.KubeConfig)
+	}
+
+	if !t.TestManagedFederation && t.InMemoryControllers {
+		glog.Info("in-memory-controllers require test-managed-federation=true - disabling.")
+		t.InMemoryControllers = false
+	}
+}
+
+func ParseFlags() {
+	registerFlags(&TestContext)
+	flag.Parse()
+	validateFlags(&TestContext)
+}

--- a/test/e2e/framework/unmanaged.go
+++ b/test/e2e/framework/unmanaged.go
@@ -1,0 +1,322 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	fedcommon "github.com/marun/fnord/pkg/apis/federation/common"
+	fedv1a1 "github.com/marun/fnord/pkg/apis/federation/v1alpha1"
+	fedclientset "github.com/marun/fnord/pkg/client/clientset_generated/clientset"
+	"github.com/marun/fnord/pkg/controller/util"
+	"github.com/marun/fnord/pkg/federatedtypes"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	kubeclientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	crclientset "k8s.io/cluster-registry/pkg/client/clientset_generated/clientset"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// Only check that the api is available once
+var checkedApi bool
+
+type UnmanagedFramework struct {
+	// To make sure that this framework cleans up after itself, no matter what,
+	// we install a Cleanup action before each test and clear it after.  If we
+	// should abort, the AfterSuite hook should run all Cleanup actions.
+	cleanupHandle CleanupActionHandle
+
+	testNamespaceName string
+
+	Config *restclient.Config
+
+	BaseName string
+}
+
+func NewUnmanagedFramework(baseName string) FederationFramework {
+	f := &UnmanagedFramework{
+		BaseName: baseName,
+	}
+	return f
+}
+
+// BeforeEach checks for federation apiserver is ready and makes a namespace.
+func (f *UnmanagedFramework) BeforeEach() {
+	// The fact that we need this feels like a bug in ginkgo.
+	// https://github.com/onsi/ginkgo/issues/222
+	f.cleanupHandle = AddCleanupAction(f.AfterEach)
+
+	if f.Config == nil {
+		By("Reading cluster configuration")
+		if TestContext.KubeConfig == "" {
+			Failf("--kubeconfig or KUBECONFIG must be specified to load client config")
+		}
+		var err error
+		f.Config, err = loadConfig(TestContext.KubeConfig, TestContext.KubeContext)
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	if !checkedApi {
+		// Check the health of the target federation
+		By("Waiting for apiserver to be ready")
+		client := f.FedClient(fmt.Sprintf("%s-setup", f.BaseName))
+		err := waitForApiserver(client)
+		Expect(err).NotTo(HaveOccurred())
+		By("apiserver is ready")
+		checkedApi = true
+	}
+}
+
+// AfterEach deletes the namespace, after reading its events.
+func (f *UnmanagedFramework) AfterEach() {
+	RemoveCleanupAction(f.cleanupHandle)
+
+	userAgent := fmt.Sprintf("%s-teardown", f.BaseName)
+
+	// DeleteNamespace at the very end in defer, to avoid any
+	// expectation failures preventing deleting the namespace.
+	defer func() {
+		if f.testNamespaceName == "" {
+			return
+		}
+		// Clear the name first to ensure other tests always get a
+		// fresh namespace even if namespace deletion fails
+		namespaceName := f.testNamespaceName
+		f.testNamespaceName = ""
+
+		client := f.KubeClient(userAgent)
+		deleteNamespace(client, namespaceName)
+	}()
+
+	// Print events if the test failed and ran in a namep.
+	if CurrentGinkgoTestDescription().Failed && f.testNamespaceName != "" {
+		kubeClient := f.KubeClient(userAgent)
+		DumpEventsInNamespace(func(opts metav1.ListOptions, ns string) (*corev1.EventList, error) {
+			return kubeClient.Core().Events(ns).List(opts)
+		}, f.testNamespaceName)
+	}
+}
+
+func (f *UnmanagedFramework) FedClient(userAgent string) fedclientset.Interface {
+	restclient.AddUserAgent(f.Config, userAgent)
+	return fedclientset.NewForConfigOrDie(f.Config)
+}
+
+func (f *UnmanagedFramework) KubeClient(userAgent string) kubeclientset.Interface {
+	restclient.AddUserAgent(f.Config, userAgent)
+	return kubeclientset.NewForConfigOrDie(f.Config)
+}
+
+func (f *UnmanagedFramework) CrClient(userAgent string) crclientset.Interface {
+	restclient.AddUserAgent(f.Config, userAgent)
+	return crclientset.NewForConfigOrDie(f.Config)
+}
+
+func (f *UnmanagedFramework) ClusterClients(userAgent string) []kubeclientset.Interface {
+	// TODO(marun) Avoid having to reload configuration on every call.
+	// Clusters may be added or removed between calls, but
+	// configuration is unlikely to change.
+	//
+	// Could also accept 'forceReload' parameter for tests that require it.
+
+	By("Obtaining a list of federated clusters")
+	fedClient := f.FedClient(userAgent)
+	clusterList, err := fedClient.FederationV1alpha1().FederatedClusters().List(metav1.ListOptions{})
+	ExpectNoError(err, fmt.Sprintf("Error retrieving list of federated clusters: %+v", err))
+
+	if len(clusterList.Items) == 0 {
+		Failf("No registered clusters found")
+	}
+
+	kubeClient := f.KubeClient(userAgent)
+	crClient := f.CrClient(userAgent)
+	clusterClients := []kubeclientset.Interface{}
+	for _, cluster := range clusterList.Items {
+		ClusterIsReadyOrFail(fedClient, cluster)
+		config, err := util.BuildClusterConfig(&cluster, kubeClient, crClient)
+		Expect(err).NotTo(HaveOccurred())
+		restclient.AddUserAgent(config, userAgent)
+		clusterClients = append(clusterClients, kubeclientset.NewForConfigOrDie(config))
+	}
+	return clusterClients
+}
+
+func (f *UnmanagedFramework) TestNamespaceName() string {
+	if f.testNamespaceName == "" {
+		By("Creating a namespace to execute the test in")
+		client := f.KubeClient(fmt.Sprintf("%s-create-namespace", f.BaseName))
+		namespaceName, err := createNamespace(client, f.BaseName)
+		Expect(err).NotTo(HaveOccurred())
+		f.testNamespaceName = namespaceName
+		By(fmt.Sprintf("Created test namespace %s", namespaceName))
+	}
+	return f.testNamespaceName
+}
+
+func (f *UnmanagedFramework) SetUpControllerFixture(kind string, adapterFactory federatedtypes.AdapterFactory) {
+	// Not supported
+}
+
+func createNamespace(client kubeclientset.Interface, baseName string) (string, error) {
+	namespaceObj := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: fmt.Sprintf("e2e-tests-%v-", baseName),
+		},
+	}
+	// Be robust about making the namespace creation call.
+	// TODO(marun) should all api calls be made 'robustly'?
+	var namespaceName string
+	if err := wait.PollImmediate(PollInterval, SingleCallTimeout, func() (bool, error) {
+		namespace, err := client.Core().Namespaces().Create(namespaceObj)
+		if err != nil {
+			Logf("Unexpected error while creating namespace: %v", err)
+			return false, nil
+		}
+		namespaceName = namespace.Name
+		return true, nil
+	}); err != nil {
+		return "", err
+	}
+	return namespaceName, nil
+}
+
+func deleteNamespace(client kubeclientset.Interface, namespaceName string) {
+	orphanDependents := false
+	if err := client.Core().Namespaces().Delete(namespaceName, &metav1.DeleteOptions{OrphanDependents: &orphanDependents}); err != nil {
+		Failf("Error while deleting namespace %s: %s", namespaceName, err)
+	}
+	// TODO(marun) Deletion handling of namespaces in fedv1 relied on
+	// a strict separation between a federated namespace and the
+	// namespace in a federated cluster.  In fedv2 this distinction
+	// has been lost where the host cluster is also a member cluster.
+	// Deletion of a namespace cannot strictly depend on namespaces in
+	// nested clusters having been removed.  It will be necessary to
+	// identify that a given namespace is in the hosting cluster and
+	// therefore does not have to be deleted before finalizer removal.
+	err := wait.PollImmediate(PollInterval, SingleCallTimeout, func() (bool, error) {
+		if _, err := client.Core().Namespaces().Get(namespaceName, metav1.GetOptions{}); err != nil {
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			Logf("Error while waiting for namespace to be removed: %v", err)
+			return false, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			Failf("Couldn't delete ns %q: %s", namespaceName, err)
+		} else {
+			Logf("Namespace %v was already deleted", namespaceName)
+		}
+	}
+}
+
+func loadConfig(configPath, context string) (*restclient.Config, error) {
+	Logf(">>> kubeConfig: %s", configPath)
+	c, err := clientcmd.LoadFromFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("error loading kubeConfig %s: %v", configPath, err.Error())
+	}
+	if context != "" {
+		Logf(">>> kubeContext: %s", context)
+		c.CurrentContext = context
+	}
+	cfg, err := clientcmd.NewDefaultClientConfig(*c, &clientcmd.ConfigOverrides{}).ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("error creating default client config: %v", err.Error())
+	}
+	return cfg, nil
+}
+
+// waitForApiserver waits for the apiserver to be ready.  It tests the
+// readiness by listing a federation resource and expecting a response
+// without error.
+func waitForApiserver(client fedclientset.Interface) error {
+	return wait.PollImmediate(time.Second, 1*time.Minute, func() (bool, error) {
+		_, err := client.FederationV1alpha1().FederatedClusters().List(metav1.ListOptions{})
+		if err != nil {
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
+// byFirstTimestamp sorts a slice of events by first timestamp, using their involvedObject's name as a tie breaker.
+type byFirstTimestamp []corev1.Event
+
+func (o byFirstTimestamp) Len() int      { return len(o) }
+func (o byFirstTimestamp) Swap(i, j int) { o[i], o[j] = o[j], o[i] }
+
+func (o byFirstTimestamp) Less(i, j int) bool {
+	if o[i].FirstTimestamp.Equal(&o[j].FirstTimestamp) {
+		return o[i].InvolvedObject.Name < o[j].InvolvedObject.Name
+	}
+	return o[i].FirstTimestamp.Before(&o[j].FirstTimestamp)
+}
+
+type EventsLister func(opts metav1.ListOptions, ns string) (*corev1.EventList, error)
+
+func DumpEventsInNamespace(eventsLister EventsLister, namespace string) {
+	By(fmt.Sprintf("Collecting events from namespace %q.", namespace))
+	events, err := eventsLister(metav1.ListOptions{}, namespace)
+	Expect(err).NotTo(HaveOccurred())
+
+	By(fmt.Sprintf("Found %d events.", len(events.Items)))
+	// Sort events by their first timestamp
+	sortedEvents := events.Items
+	if len(sortedEvents) > 1 {
+		sort.Sort(byFirstTimestamp(sortedEvents))
+	}
+	for _, e := range sortedEvents {
+		Logf("At %v - event for %v: %v %v: %v", e.FirstTimestamp, e.InvolvedObject.Name, e.Source, e.Reason, e.Message)
+	}
+	// Note that we don't wait for any Cleanup to propagate, which means
+	// that if you delete a bunch of pods right before ending your test,
+	// you may or may not see the killing/deletion/Cleanup events.
+}
+
+// ClusterIsReadyOrFail checks whether the named cluster has been
+// marked as ready by the federated cluster controller.  The cluster
+// controller records the results of health checks on member clusters
+// in the status of federated clusters.
+func ClusterIsReadyOrFail(client fedclientset.Interface, cluster fedv1a1.FederatedCluster) {
+	clusterName := cluster.Name
+	By(fmt.Sprintf("Checking readiness of cluster %q", clusterName))
+	err := wait.PollImmediate(PollInterval, SingleCallTimeout, func() (bool, error) {
+		for _, condition := range cluster.Status.Conditions {
+			if condition.Type == fedcommon.ClusterReady && condition.Status == corev1.ConditionTrue {
+				return true, nil
+			}
+		}
+		_, err := client.FederationV1alpha1().FederatedClusters().Get(clusterName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return false, nil
+	})
+	ExpectNoError(err, fmt.Sprintf("Unexpected error in verifying if cluster %q is ready: %+v", clusterName, err))
+	Logf("Cluster %s is Ready", clusterName)
+}

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/marun/fnord/test/e2e/framework/ginkgowrapper"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pborman/uuid"
+)
+
+const (
+	// How long to try single API calls (like 'get' or 'list'). Used to prevent
+	// transient failures from failing tests.
+	// TODO: client should not apply this timeout to Watch calls. Increased from 30s until that is fixed.
+	PollInterval      = 2 * time.Second
+	SingleCallTimeout = 5 * time.Minute
+)
+
+// unique identifier of the e2e run
+var RunId = uuid.NewUUID()
+
+func nowStamp() string {
+	return time.Now().Format(time.StampMilli)
+}
+
+func log(level string, format string, args ...interface{}) {
+	fmt.Fprintf(GinkgoWriter, nowStamp()+": "+level+": "+format+"\n", args...)
+}
+
+func Errorf(format string, args ...interface{}) {
+	log("ERROR", format, args...)
+}
+
+func Logf(format string, args ...interface{}) {
+	log("INFO", format, args...)
+}
+
+func Failf(format string, args ...interface{}) {
+	FailfWithOffset(1, format, args...)
+}
+
+// FailfWithOffset calls "Fail" and logs the error at "offset" levels above its caller
+// (for example, for call chain f -> g -> FailfWithOffset(1, ...) error would be logged for "f").
+func FailfWithOffset(offset int, format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	log("INFO", msg)
+	ginkgowrapper.Fail(nowStamp()+": "+msg, 1+offset)
+}
+
+func ExpectNoError(err error, explain ...interface{}) {
+	ExpectNoErrorWithOffset(1, err, explain...)
+}
+
+// ExpectNoErrorWithOffset checks if "err" is set, and if so, fails assertion while logging the error at "offset" levels above its caller
+// (for example, for call chain f -> g -> ExpectNoErrorWithOffset(1, ...) error would be logged for "f").
+func ExpectNoErrorWithOffset(offset int, err error, explain ...interface{}) {
+	if err != nil {
+		Logf("Unexpected error occurred: %v", err)
+	}
+	ExpectWithOffset(1+offset, err).NotTo(HaveOccurred(), explain...)
+}

--- a/test/integration/crud_test.go
+++ b/test/integration/crud_test.go
@@ -30,14 +30,16 @@ import (
 
 // TestCrud validates create/read/update/delete operations for federated types.
 func TestCrud(t *testing.T) {
-	fedFixture := framework.SetUpFederationFixture(t, 2)
-	defer fedFixture.TearDown(t)
+	tl := framework.NewIntegrationLogger(t)
+	fedFixture := framework.SetUpFederationFixture(tl, 2)
+	defer fedFixture.TearDown(tl)
 
 	fedTypeConfigs := federatedtypes.FederatedTypeConfigs()
 	for kind, fedTypeConfig := range fedTypeConfigs {
 		t.Run(kind, func(t *testing.T) {
-			fixture, crudTester, obj, _ := initCrudTest(t, fedFixture, fedTypeConfig.AdapterFactory, kind)
-			defer fixture.TearDown(t)
+			tl := framework.NewIntegrationLogger(t)
+			fixture, crudTester, obj, _ := initCrudTest(tl, fedFixture, fedTypeConfig.AdapterFactory, kind)
+			defer fixture.TearDown(tl)
 
 			crudTester.CheckLifecycle(obj)
 		})
@@ -45,20 +47,20 @@ func TestCrud(t *testing.T) {
 }
 
 // initCrudTest initializes common elements of a crud test
-func initCrudTest(t *testing.T, fedFixture *framework.FederationFixture, adapterFactory federatedtypes.AdapterFactory, kind string) (
+func initCrudTest(tl common.TestLogger, fedFixture *framework.FederationFixture, adapterFactory federatedtypes.AdapterFactory, kind string) (
 	*framework.ControllerFixture, *common.FederatedTypeCrudTester, pkgruntime.Object, federatedtypes.FederatedTypeAdapter) {
 	// TODO(marun) stop requiring user agent when creating new config or clients
 	userAgent := fmt.Sprintf("crud-test-%s", kind)
-	fedConfig := fedFixture.FedApi.NewConfig(t, userAgent)
-	kubeConfig := fedFixture.KubeApi.NewConfig(t, userAgent)
-	crConfig := fedFixture.CrApi.NewConfig(t, userAgent)
-	fixture := framework.NewControllerFixture(t, kind, adapterFactory, fedConfig, kubeConfig, crConfig)
+	fedConfig := fedFixture.FedApi.NewConfig(tl, userAgent)
+	kubeConfig := fedFixture.KubeApi.NewConfig(tl, userAgent)
+	crConfig := fedFixture.CrApi.NewConfig(tl, userAgent)
+	fixture := framework.NewControllerFixture(tl, kind, adapterFactory, fedConfig, kubeConfig, crConfig)
 
-	client := fedFixture.FedApi.NewClient(t, userAgent)
+	client := fedFixture.FedApi.NewClient(tl, userAgent)
 	adapter := adapterFactory(client)
 
-	clusterClients := fedFixture.ClusterClients(t, userAgent)
-	crudTester := framework.NewFederatedTypeCrudTester(t, adapter, clusterClients)
+	clusterClients := fedFixture.ClusterClients(tl, userAgent)
+	crudTester := framework.NewFederatedTypeCrudTester(tl, adapter, clusterClients)
 
 	obj := federatedtypes.NewTestObject(kind, uuid.New())
 

--- a/test/integration/crud_test.go
+++ b/test/integration/crud_test.go
@@ -50,11 +50,12 @@ func TestCrud(t *testing.T) {
 func initCrudTest(tl common.TestLogger, fedFixture *framework.FederationFixture, adapterFactory federatedtypes.AdapterFactory, kind string) (
 	*framework.ControllerFixture, *common.FederatedTypeCrudTester, pkgruntime.Object, federatedtypes.FederatedTypeAdapter) {
 	// TODO(marun) stop requiring user agent when creating new config or clients
-	userAgent := fmt.Sprintf("crud-test-%s", kind)
-	fedConfig := fedFixture.FedApi.NewConfig(tl, userAgent)
-	kubeConfig := fedFixture.KubeApi.NewConfig(tl, userAgent)
-	crConfig := fedFixture.CrApi.NewConfig(tl, userAgent)
+	fedConfig := fedFixture.FedApi.NewConfig(tl)
+	kubeConfig := fedFixture.KubeApi.NewConfig(tl)
+	crConfig := fedFixture.CrApi.NewConfig(tl)
 	fixture := framework.NewControllerFixture(tl, kind, adapterFactory, fedConfig, kubeConfig, crConfig)
+
+	userAgent := fmt.Sprintf("crud-test-%s", kind)
 
 	client := fedFixture.FedApi.NewClient(tl, userAgent)
 	adapter := adapterFactory(client)

--- a/test/integration/framework/controller.go
+++ b/test/integration/framework/controller.go
@@ -17,10 +17,9 @@ limitations under the License.
 package framework
 
 import (
-	"testing"
-
 	"github.com/marun/fnord/pkg/controller/sync"
 	"github.com/marun/fnord/pkg/federatedtypes"
+	"github.com/marun/fnord/test/common"
 	restclient "k8s.io/client-go/rest"
 )
 
@@ -30,7 +29,7 @@ type ControllerFixture struct {
 }
 
 // NewControllerFixture initializes a new controller fixture
-func NewControllerFixture(t *testing.T, kind string, adapterFactory federatedtypes.AdapterFactory, fedConfig, kubeConfig, crConfig *restclient.Config) *ControllerFixture {
+func NewControllerFixture(tl common.TestLogger, kind string, adapterFactory federatedtypes.AdapterFactory, fedConfig, kubeConfig, crConfig *restclient.Config) *ControllerFixture {
 	f := &ControllerFixture{
 		stopChan: make(chan struct{}),
 	}
@@ -38,6 +37,6 @@ func NewControllerFixture(t *testing.T, kind string, adapterFactory federatedtyp
 	return f
 }
 
-func (f *ControllerFixture) TearDown(t *testing.T) {
+func (f *ControllerFixture) TearDown(tl common.TestLogger) {
 	close(f.stopChan)
 }

--- a/test/integration/framework/crapi.go
+++ b/test/integration/framework/crapi.go
@@ -105,10 +105,11 @@ func (f *ClusterRegistryApiFixture) TearDown(tl common.TestLogger) {
 }
 
 func (f *ClusterRegistryApiFixture) NewClient(tl common.TestLogger, userAgent string) clientset.Interface {
-	config := f.NewConfig(tl, userAgent)
+	config := f.NewConfig(tl)
+	rest.AddUserAgent(config, userAgent)
 	return clientset.NewForConfigOrDie(config)
 }
 
-func (f *ClusterRegistryApiFixture) NewConfig(tl common.TestLogger, userAgent string) *rest.Config {
-	return f.SecureConfigFixture.NewClientConfig(tl, f.Host, userAgent)
+func (f *ClusterRegistryApiFixture) NewConfig(tl common.TestLogger) *rest.Config {
+	return f.SecureConfigFixture.NewClientConfig(tl, f.Host)
 }

--- a/test/integration/framework/etcd.go
+++ b/test/integration/framework/etcd.go
@@ -17,9 +17,8 @@ limitations under the License.
 package framework
 
 import (
-	"testing"
-
 	"github.com/kubernetes-sig-testing/frameworks/integration"
+	"github.com/marun/fnord/test/common"
 )
 
 var (
@@ -27,26 +26,26 @@ var (
 	refCount int
 )
 
-func SetUpEtcd(t *testing.T) string {
+func SetUpEtcd(tl common.TestLogger) string {
 	if etcd == nil {
 		etcd = &integration.Etcd{}
 		err := etcd.Start()
 		if err != nil {
 			etcd = nil
-			t.Fatalf("Error starting etcd: %v", err)
+			tl.Fatalf("Error starting etcd: %v", err)
 		}
 	}
 	refCount += 1
 	return etcd.URL.String()
 }
 
-func TearDownEtcd(t *testing.T) {
+func TearDownEtcd(tl common.TestLogger) {
 	if etcd != nil {
 		refCount -= 1
 		if refCount <= 0 {
 			err := etcd.Stop()
 			if err != nil {
-				t.Errorf("Error stopping etcd: %v", err)
+				tl.Errorf("Error stopping etcd: %v", err)
 			}
 			etcd = nil
 		}

--- a/test/integration/framework/fedapi.go
+++ b/test/integration/framework/fedapi.go
@@ -98,10 +98,11 @@ func (f *FederationApiFixture) TearDown(tl common.TestLogger) {
 }
 
 func (f *FederationApiFixture) NewClient(tl common.TestLogger, userAgent string) clientset.Interface {
-	config := f.NewConfig(tl, userAgent)
+	config := f.NewConfig(tl)
+	rest.AddUserAgent(config, userAgent)
 	return clientset.NewForConfigOrDie(config)
 }
 
-func (f *FederationApiFixture) NewConfig(tl common.TestLogger, userAgent string) *rest.Config {
-	return f.SecureConfigFixture.NewClientConfig(tl, f.Host, userAgent)
+func (f *FederationApiFixture) NewConfig(tl common.TestLogger) *rest.Config {
+	return f.SecureConfigFixture.NewClientConfig(tl, f.Host)
 }

--- a/test/integration/framework/federation.go
+++ b/test/integration/framework/federation.go
@@ -77,7 +77,7 @@ func (f *FederationFixture) setUp(tl common.TestLogger, clusterCount int) {
 	f.stopChan = make(chan struct{})
 	monitorPeriod := 1 * time.Second
 	tl.Logf("Starting cluster controller")
-	federatedcluster.StartClusterController(f.FedApi.NewConfig(tl, ""), f.KubeApi.NewConfig(tl, ""), f.CrApi.NewConfig(tl, ""), f.stopChan, monitorPeriod)
+	federatedcluster.StartClusterController(f.FedApi.NewConfig(tl), f.KubeApi.NewConfig(tl), f.CrApi.NewConfig(tl), f.stopChan, monitorPeriod)
 
 	tl.Log("Federation started.")
 }
@@ -151,7 +151,7 @@ func (f *FederationFixture) registerCluster(tl common.TestLogger, host string) s
 func (f *FederationFixture) createSecret(tl common.TestLogger, clusterFixture *KubernetesApiFixture, clusterName string) string {
 	// Do not include the host - it will need to be sourced from the
 	// Cluster resource.
-	config := clusterFixture.SecureConfigFixture.NewClientConfig(tl, "", userAgent)
+	config := clusterFixture.SecureConfigFixture.NewClientConfig(tl, "")
 	kubeConfig := CreateKubeConfig(config)
 
 	// Flatten the kubeconfig to ensure that all the referenced file

--- a/test/integration/framework/kubeapi.go
+++ b/test/integration/framework/kubeapi.go
@@ -104,10 +104,11 @@ func (f *KubernetesApiFixture) TearDown(tl common.TestLogger) {
 }
 
 func (f *KubernetesApiFixture) NewClient(tl common.TestLogger, userAgent string) clientset.Interface {
-	config := f.NewConfig(tl, userAgent)
+	config := f.NewConfig(tl)
+	rest.AddUserAgent(config, userAgent)
 	return clientset.NewForConfigOrDie(config)
 }
 
-func (f *KubernetesApiFixture) NewConfig(tl common.TestLogger, userAgent string) *rest.Config {
-	return f.SecureConfigFixture.NewClientConfig(tl, f.Host, userAgent)
+func (f *KubernetesApiFixture) NewConfig(tl common.TestLogger) *rest.Config {
+	return f.SecureConfigFixture.NewClientConfig(tl, f.Host)
 }

--- a/test/integration/framework/logger.go
+++ b/test/integration/framework/logger.go
@@ -17,12 +17,37 @@ limitations under the License.
 package framework
 
 import (
-	"github.com/marun/fnord/pkg/federatedtypes"
+	"testing"
+
 	"github.com/marun/fnord/test/common"
-	"k8s.io/apimachinery/pkg/util/wait"
-	clientset "k8s.io/client-go/kubernetes"
 )
 
-func NewFederatedTypeCrudTester(tl common.TestLogger, adapter federatedtypes.FederatedTypeAdapter, clusterClients []clientset.Interface) *common.FederatedTypeCrudTester {
-	return common.NewFederatedTypeCrudTester(tl, adapter, clusterClients, DefaultWaitInterval, wait.ForeverTestTimeout)
+type integrationLogger struct {
+	t *testing.T
+}
+
+func NewIntegrationLogger(t *testing.T) common.TestLogger {
+	return &integrationLogger{
+		t: t,
+	}
+}
+
+func (l *integrationLogger) Errorf(format string, args ...interface{}) {
+	l.t.Errorf(format, args...)
+}
+
+func (l *integrationLogger) Fatal(args ...interface{}) {
+	l.t.Fatal(args...)
+}
+
+func (l *integrationLogger) Fatalf(format string, args ...interface{}) {
+	l.t.Fatalf(format, args...)
+}
+
+func (l *integrationLogger) Log(args ...interface{}) {
+	l.t.Log(args...)
+}
+
+func (l *integrationLogger) Logf(format string, args ...interface{}) {
+	l.t.Logf(format, args...)
 }

--- a/test/integration/framework/secureconfig.go
+++ b/test/integration/framework/secureconfig.go
@@ -82,7 +82,7 @@ func (f *SecureConfigFixture) TearDown(tl common.TestLogger) {
 	}
 }
 
-func (f *SecureConfigFixture) NewClientConfig(tl common.TestLogger, host, userAgent string) *rest.Config {
+func (f *SecureConfigFixture) NewClientConfig(tl common.TestLogger, host string) *rest.Config {
 	// The server ca file is written on startup, and may not be immediately available
 	f.waitForServerCAFile(tl)
 
@@ -90,7 +90,6 @@ func (f *SecureConfigFixture) NewClientConfig(tl common.TestLogger, host, userAg
 		Host:            host,
 		TLSClientConfig: f.newTLSClientConfig(tl),
 	}
-	rest.AddUserAgent(config, userAgent)
 	return config
 }
 

--- a/test/integration/framework/secureconfig.go
+++ b/test/integration/framework/secureconfig.go
@@ -22,9 +22,9 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"testing"
 	"time"
 
+	"github.com/marun/fnord/test/common"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/cert"
@@ -38,63 +38,63 @@ type SecureConfigFixture struct {
 	CACertFile   string
 }
 
-func SetUpSecureConfigFixture(t *testing.T) *SecureConfigFixture {
+func SetUpSecureConfigFixture(tl common.TestLogger) *SecureConfigFixture {
 	f := &SecureConfigFixture{}
-	f.setUp(t)
+	f.setUp(tl)
 	return f
 }
 
-func (f *SecureConfigFixture) setUp(t *testing.T) {
-	defer TearDownOnPanic(t, f)
+func (f *SecureConfigFixture) setUp(tl common.TestLogger) {
+	defer TearDownOnPanic(tl, f)
 
 	var err error
 
 	f.CertDir, err = ioutil.TempDir("", "fed-test-certs")
 	if err != nil {
-		t.Fatal(err)
+		tl.Fatal(err)
 	}
 	f.ServerCAFile = path.Join(f.CertDir, "apiserver.crt")
 
 	f.Key, err = cert.NewPrivateKey()
 	if err != nil {
-		t.Fatal(err)
+		tl.Fatal(err)
 	}
 
 	f.CACert, err = cert.NewSelfSignedCACert(cert.Config{CommonName: "client-ca"}, f.Key)
 	if err != nil {
-		t.Fatal(err)
+		tl.Fatal(err)
 	}
 
 	caCertFile, err := ioutil.TempFile(f.CertDir, "client-ca.crt")
 	if err != nil {
-		t.Fatal(err)
+		tl.Fatal(err)
 	}
 	f.CACertFile = caCertFile.Name()
 
 	if err := ioutil.WriteFile(f.CACertFile, cert.EncodeCertPEM(f.CACert), 0644); err != nil {
-		t.Fatal(err)
+		tl.Fatal(err)
 	}
 }
 
-func (f *SecureConfigFixture) TearDown(t *testing.T) {
+func (f *SecureConfigFixture) TearDown(tl common.TestLogger) {
 	if len(f.CertDir) >= 0 {
 		os.RemoveAll(f.CertDir)
 	}
 }
 
-func (f *SecureConfigFixture) NewClientConfig(t *testing.T, host, userAgent string) *rest.Config {
+func (f *SecureConfigFixture) NewClientConfig(tl common.TestLogger, host, userAgent string) *rest.Config {
 	// The server ca file is written on startup, and may not be immediately available
-	f.waitForServerCAFile(t)
+	f.waitForServerCAFile(tl)
 
 	config := &rest.Config{
 		Host:            host,
-		TLSClientConfig: f.newTLSClientConfig(t),
+		TLSClientConfig: f.newTLSClientConfig(tl),
 	}
 	rest.AddUserAgent(config, userAgent)
 	return config
 }
 
-func (f *SecureConfigFixture) waitForServerCAFile(t *testing.T) {
+func (f *SecureConfigFixture) waitForServerCAFile(tl common.TestLogger) {
 	err := wait.PollImmediate(100*time.Millisecond, 10*time.Second, func() (done bool, err error) {
 		if _, err := os.Stat(f.ServerCAFile); err == nil {
 			return true, nil
@@ -102,14 +102,14 @@ func (f *SecureConfigFixture) waitForServerCAFile(t *testing.T) {
 		return false, err
 	})
 	if err != nil {
-		t.Fatalf("Error reading CA file: %s: %v\nHas the server been started?", f.ServerCAFile, err)
+		tl.Fatalf("Error reading CA file: %s: %v\nHas the server been started?", f.ServerCAFile, err)
 	}
 }
 
-func (f *SecureConfigFixture) newTLSClientConfig(t *testing.T) rest.TLSClientConfig {
+func (f *SecureConfigFixture) newTLSClientConfig(tl common.TestLogger) rest.TLSClientConfig {
 	key, err := cert.NewPrivateKey()
 	if err != nil {
-		t.Fatal(err)
+		tl.Fatal(err)
 	}
 
 	clientCert, err := cert.NewSignedCert(
@@ -120,7 +120,7 @@ func (f *SecureConfigFixture) newTLSClientConfig(t *testing.T) rest.TLSClientCon
 		key, f.CACert, f.Key,
 	)
 	if err != nil {
-		t.Fatal(err)
+		tl.Fatal(err)
 	}
 
 	return rest.TLSClientConfig{

--- a/test/integration/framework/util.go
+++ b/test/integration/framework/util.go
@@ -19,9 +19,9 @@ package framework
 import (
 	"net"
 	"strconv"
-	"testing"
 	"time"
 
+	"github.com/marun/fnord/test/common"
 	"k8s.io/client-go/rest"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -56,13 +56,13 @@ func FindFreeLocalPort() (int, error) {
 // SetUp is likely to be fixture-specific, but TearDown needs to be
 // consistent to enable TearDownOnPanic.
 type TestFixture interface {
-	TearDown(t *testing.T)
+	TearDown(tl common.TestLogger)
 }
 
 // TearDownOnPanic can be used to ensure cleanup on setup failure.
-func TearDownOnPanic(t *testing.T, f TestFixture) {
+func TearDownOnPanic(tl common.TestLogger, f TestFixture) {
 	if r := recover(); r != nil {
-		f.TearDown(t)
+		f.TearDown(tl)
 		panic(r)
 	}
 }


### PR DESCRIPTION
This PR adds a crud e2e test that can run against both test-managed and previously deployed federations.  The semantics of invocation against deployed federation are consistent with how kube does it, e.g.

```
cd test/e2e && go test -v --kubeconfig=/path/to/kubeconfig
```

If ``--kubeconfig`` is not provided, the e2e suite will target a test-managed federation.  This duplicates how integration tests are run, but allows for future variation in the implementation of a test-managed federation (e.g. deploy using kubeadm using dind or hollow nodes).

cc: @font 